### PR TITLE
There is no real need for R 3.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Diversity-Dependent Diversification
 Version: 4.0
 Date: 2019-04-06
-Depends: R (>= 3.5.0)
+Depends: R
 Imports: deSolve, ape, phytools, subplex, Matrix, expm, SparseM
 Suggests: testthat
 Author: Rampal S. Etienne & Bart Haegeman

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,6 @@ Type: Package
 Title: Diversity-Dependent Diversification
 Version: 4.0
 Date: 2019-04-06
-Depends: R
 Imports: deSolve, ape, phytools, subplex, Matrix, expm, SparseM
 Suggests: testthat
 Author: Rampal S. Etienne & Bart Haegeman


### PR DESCRIPTION
DDD failed to build on my computer with R 3.4.2, as recently it was added it needed R 3.5.0. 

Removing that constraint had no dire consequence (see [the Travis logs](https://travis-ci.org/richelbilderbeek/DDD/builds/526877886))and I suggest to lift it, so that everyone can still use DDD.