### PR TITLE
Fix bug: if there is only one non-zero element to sample from in 'rng_respecting_sample', pick that one element, instead of giving a non-descriptive error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,6 @@ Type: Package
 Title: Diversity-Dependent Diversification
 Version: 4.1
 Date: 2019-06-20
-Depends: R (>= 3.5.0)
 Imports: deSolve, ape, phytools, subplex, Matrix, expm, SparseM
 Suggests: testthat, testit
 Author: Rampal S. Etienne & Bart Haegeman

--- a/R/dd_utils.R
+++ b/R/dd_utils.R
@@ -864,5 +864,7 @@ rng_respecting_sample <- function(x, size, replace, prob) {
   which_non_zero <- prob > 0.0
   non_zero_prob <- prob[which_non_zero]
   non_zero_x <- x[which_non_zero]
+  testit::assert(length(non_zero_x) == length(non_zero_prob))
+  if (length(non_zero_x) == 1) return (non_zero_x)
   return(sample(x = non_zero_x, size = size, replace = replace, prob = non_zero_prob))
 }

--- a/tests/testthat/test-rng_respecting_sample.R
+++ b/tests/testthat/test-rng_respecting_sample.R
@@ -51,3 +51,11 @@ test_that("use, two non-zero probabilities", {
   testit::assert(sum(draws_2 == 2) > 0)
   expect_equal(draws_1, draws_2)
 })
+
+test_that("if only one element is non-zero, pick that element", {
+  expect_silent(
+    rng_respecting_sample(
+      x = 1:4, size = 1, replace = TRUE, prob = c(0.0, 0.4, 0.0, 0.0)
+    )
+  )
+})


### PR DESCRIPTION
I found this bug at @xieshu95 and we've added a test and offered the solution.

Happy to help :+1: