### PR TITLE
Only use quadmath on 64-bit archs, fixes #17

### DIFF
--- a/src/dd_loglik_rhs_FORTRAN.f95
+++ b/src/dd_loglik_rhs_FORTRAN.f95
@@ -215,6 +215,7 @@
        
       SUBROUTINE dd_runmodtd (neq, t, Conc, dConc, yout, ip)
       USE dd_dimmod
+      USE iso_c_binding
       IMPLICIT NONE
 !......................... declaration section.............................
       INTEGER           :: neq, ip(*), i, ii, M
@@ -224,7 +225,7 @@
       DOUBLE PRECISION  :: nn((N - kk) + 2)
       DOUBLE PRECISION  :: FF1, FF2, FF3, En
       DOUBLE PRECISION  :: c, t1, y
-      REAL(16)          :: Envec(N - kk)
+      REAL(c_intptr_t * 2) :: Envec(N - kk)
 
 ! parameters - named here
       DOUBLE PRECISION rn(2)


### PR DESCRIPTION
Hi, we are trying to upgrade the Windows toolchain to GCC-8 on CRAN.

Your use of quadmath seems to overflow on 32-bit systems, resulting in a crash with gcc 8. See https://github.com/rsetienne/DDD/issues/17

The following is a simple fix that only uses quadmath on 64-bit systems (`c_intptr_t` equals 4 on 32-bit and 8 on 64-bit). With this, the package should pass on [winbuilder](https://win-builder.r-project.org/upload.aspx) with the GCC-8 toolchain.