### PR TITLE
r-lib/actions/setup-r macOS gfortran temporary fix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r
+      - uses: r-lib/actions/setup-r@a761969
         with:
           r-version: ${{ matrix.config.r }}
           

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Force gfortran under mac
         if: runner.os == 'macOS'
-        run: /usr/local/bin/brew install gfortran
+        run: /usr/local/bin/brew install gfortran-8
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@a761969
+      - uses: r-lib/actions/setup-r@a76196994633e92987350cb0bce04050a89d3f50
         with:
           r-version: ${{ matrix.config.r }}
           

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,6 +75,11 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
+
+      - name: Force gfortran under mac
+        if: runner.os == 'macOS'
+        run: /usr/local/bin/brew install gfortran
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,6 +79,7 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          remotes::install_cran("crayon")
           if (.Platform$OS.type == "unix") remotes::install_cran("doMC")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Force gfortran under mac
         if: runner.os == 'macOS'
-        run: /usr/local/bin/brew install gfortran-8
+        run: /usr/local/bin/brew install gfortran-9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r
         with:
           r-version: ${{ matrix.config.r }}
           
@@ -74,11 +74,6 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-
-      - name: Force gfortran under mac
-        if: runner.os == 'macOS'
-        run: /usr/local/bin/brew install gfortran-9
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DDD
 
-Branch|[GitHub Actions](https://github.com/rsetienne/DAISIE/actions)|[Codecov](https://www.codecov.io)
+Branch|[GitHub Actions](https://github.com/rsetienne/DDD/actions)|[Codecov](https://www.codecov.io)
 ---|---|---
 `master`|[![Build Status](https://github.com/rsetienne/DDD/workflows/R-CMD-check/badge.svg?branch=master)](https://github.com/rsetienne/DDD/actions)|[![codecov.io](https://codecov.io/github/rsetienne/DDD/coverage.svg?branch=master)](https://codecov.io/github/rsetienne/DDD/branch/master)
 `develop`|[![Build Status](https://github.com/rsetienne/DDD/workflows/R-CMD-check/badge.svg?branch=develop)](https://github.com/rsetienne/DDD/actions)|[![codecov.io](https://codecov.io/github/rsetienne/DDD/coverage.svg?branch=develop)](https://codecov.io/github/rsetienne/DDD/branch/develop)


### PR DESCRIPTION
This is a temporary fix to explicitly install the r-lib/actions/setup-r versions in r-lib/actions/setup-r@a761969.

Solves issues with CI running FORTRAN code on Mac OS X 10.15.7 19H114 as seen [here](https://github.com/rsetienne/DDD/runs/1810877519#step:10:65) and [here](https://github.com/rsetienne/DAISIE/runs/1762516029#step:9:178) (rsetienne/DDD@68c54df and rsetienne/DAISIE@64b4585).

This should not be used permanently, but only until PR which fixed this at the back-end https://github.com/r-lib/actions/pull/232 propagates to setup-r@v1 or another subsequent tag.