### PR TITLE
Use r-lib/setup-r@v1 again

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - master
       - develop
-      - gha
       - richel
 
   pull_request:
@@ -14,7 +13,6 @@ on:
       - main
       - master
       - develop
-      - gha
       - richel
 
 name: R-CMD-check
@@ -42,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@a76196994633e92987350cb0bce04050a89d3f50
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
           


### PR DESCRIPTION
Can (and should) use r-lib/setup-r@v1 again.

See Neves-P/DAISIErobustness@cb6ae80f545f01e8a2ebe0c134f915d8f804c7b4