### PR TITLE
add verbose flag to simplex optimization

### DIFF
--- a/DDD.Rproj
+++ b/DDD.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: cbff7951-4a06-4670-bbdf-df0ae63c05bf
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DDD
 Type: Package
 Title: Diversity-Dependent Diversification
-Version: 5.2.3
+Version: 5.2.4
 Date: 2024-11-26
 Depends: R (>= 3.5.0)
 Imports:

--- a/R/bd_ML.R
+++ b/R/bd_ML.R
@@ -57,7 +57,7 @@
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param num_cycles the number of cycles of opimization. If set at Inf, it will
 #' do as many cycles as needed to meet the tolerance set for the target function.
@@ -102,7 +102,7 @@ bd_ML = function(brts,
     tol = c(1E-3, 1E-4, 1E-6),
     maxiter = 1000 * round((1.25)^length(idparsopt)),
     changeloglikifnoconv = FALSE,
-    optimmethod = 'subplex',
+    optimmethod = 'simplex',
     num_cycles = 1,
     methode = 'odeint::runge_kutta_cash_karp54',
     verbose = FALSE)

--- a/R/dd_KI_ML.R
+++ b/R/dd_KI_ML.R
@@ -78,7 +78,7 @@
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param num_cycles the number of cycles of opimization. If set at Inf, it will
 #' do as many cycles as needed to meet the tolerance set for the target function.
@@ -140,7 +140,7 @@ dd_KI_ML = function(brtsM,
     tol = c(1E-3, 1E-4, 1E-6),
     maxiter = 1000 * round((1.25)^length(idparsopt)),
     changeloglikifnoconv = FALSE,
-    optimmethod = 'subplex',
+    optimmethod = 'simplex',
     num_cycles = 1,
     methode = 'analytical',
     correction = TRUE,

--- a/R/dd_LR.R
+++ b/R/dd_LR.R
@@ -60,7 +60,7 @@
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param methode The method used to solve the master equation, default is
 #' 'analytical' which uses matrix exponentiation; alternatively numerical ODE
@@ -120,7 +120,7 @@ dd_LR = function(
    tol = c(1E-3,1E-4,1E-6),
    maxiter = 2000,
    changeloglikifnoconv = FALSE,
-   optimmethod = 'subplex',
+   optimmethod = 'simplex',
    methode = 'analytical'   
    )
 {

--- a/R/dd_ML.R
+++ b/R/dd_ML.R
@@ -99,7 +99,7 @@ parsfixdefault = function(ddmodel,brts,missnumspec,idparsopt)
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param num_cycles the number of cycles of opimization. If set at Inf, it will
 #' do as many cycles as needed to meet the tolerance set for the target function.
@@ -147,7 +147,7 @@ dd_ML = function(
   tol = c(1E-3, 1E-4, 1E-6),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = 'subplex',
+  optimmethod = 'simplex',
   num_cycles = 1,
   methode = 'analytical',
   verbose = FALSE)

--- a/R/dd_MS_ML.R
+++ b/R/dd_MS_ML.R
@@ -78,7 +78,7 @@
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param num_cycles the number of cycles of opimization. If set at Inf, it will
 #' do as many cycles as needed to meet the tolerance set for the target function.
@@ -136,7 +136,7 @@ dd_MS_ML = function(brtsM,
     tol = c(1E-3, 1E-4, 1E-6),
     maxiter = 1000 * round((1.25)^length(idparsopt)),
     changeloglikifnoconv = FALSE,
-    optimmethod = 'subplex',
+    optimmethod = 'simplex',
     num_cycles = 1,
     methode = 'ode45',
     correction = FALSE,

--- a/R/dd_SR_ML.R
+++ b/R/dd_SR_ML.R
@@ -71,7 +71,7 @@
 #' @param changeloglikifnoconv if TRUE the loglik will be set to -Inf if ML
 #' does not converge
 #' @param optimmethod Method used in optimization of the likelihood. Current
-#' default is 'subplex'. Alternative is 'simplex' (default of previous
+#' default is 'simplex'. Alternative is 'subplex' (default of previous
 #' versions)
 #' @param num_cycles the number of cycles of opimization. If set at Inf, it will
 #' do as many cycles as needed to meet the tolerance set for the target function.
@@ -128,7 +128,7 @@ dd_SR_ML = function(brts,
     tol = c(1E-3, 1E-4, 1E-6),
     maxiter = 1000 * round((1.25)^length(idparsopt)),
     changeloglikifnoconv = FALSE,
-    optimmethod = 'subplex',
+    optimmethod = 'simplex',
     num_cycles = 1,
     methode = 'analytical',
     verbose = FALSE)

--- a/R/dd_utils.R
+++ b/R/dd_utils.R
@@ -514,11 +514,12 @@ sample2 = function(x,size,replace = FALSE,prob = NULL)
 #' 
 #' @param fun Function to be optimized
 #' @param trparsopt Initial guess of the parameters to be optimized
-#' @param ... Any other arguments of the function to be optimimzed, or settings
+#' @param ... Any other arguments of the function to be optimimized, or settings
 #' of the optimization routine
 #' @param optimpars Parameters of the optimization: relative tolerance in
 #' function arguments, relative tolerance in function value, absolute tolerance
 #' in function arguments, and maximum number of iterations
+#' @param verbose adds verbose output of intermediate evaluations
 #' @return \item{out}{ A list containing optimal function arguments
 #' (\code{par}, the optimal function value (\code{fvalues}) and whether the
 #' optimization converged (\code{conv})}.
@@ -529,7 +530,8 @@ sample2 = function(x,size,replace = FALSE,prob = NULL)
 #' cat("No examples")
 #' 
 #' @export simplex
-simplex = function(fun,trparsopt,optimpars,verbose = TRUE,...)
+simplex = function(fun,trparsopt,optimpars,
+                   verbose = TRUE,...)
 {
   numpar = length(trparsopt)
   reltolx = optimpars[1]

--- a/R/dd_utils.R
+++ b/R/dd_utils.R
@@ -529,7 +529,7 @@ sample2 = function(x,size,replace = FALSE,prob = NULL)
 #' cat("No examples")
 #' 
 #' @export simplex
-simplex = function(fun,trparsopt,optimpars,...)
+simplex = function(fun,trparsopt,optimpars,verbose = TRUE,...)
 {
   numpar = length(trparsopt)
   reltolx = optimpars[1]
@@ -566,7 +566,7 @@ simplex = function(fun,trparsopt,optimpars,...)
      string = paste(string, untransform_pars(v[i,1]), sep = " ")
   }
   string = paste(string, -fv[1], how, "\n", sep = " ")
-  cat(string)
+  if (verbose) cat(string)
   utils::flush.console()
   
   tmp = order(fv)
@@ -673,15 +673,15 @@ simplex = function(fun,trparsopt,optimpars,...)
          string = paste(string, untransform_pars(v[i,1]), sep = " ")
      }
      string = paste(string, -fv[1], how, "\n", sep = " ")
-     cat(string)
+     if (verbose) cat(string)
      utils::flush.console()
      v2 = t(matrix(rep(v[,1],each = numpar + 1),nrow = numpar + 1))
   }
   if(itercount < maxiter)
   {
-     cat("Optimization has terminated successfully.","\n")
+    if (verbose) cat("Optimization has terminated successfully.","\n")
   } else {
-     cat("Maximum number of iterations has been exceeded.","\n")
+    if (verbose) cat("Maximum number of iterations has been exceeded.","\n")
   }
   out = list(par = v[,1], fvalues = -fv[1], conv = as.numeric(itercount > maxiter))
   invisible(out)
@@ -707,6 +707,7 @@ simplex = function(fun,trparsopt,optimpars,...)
 #' @param jitter Perturbation of an initial parameter value when precisely equal to 0.5;
 #' this is only relevant when subplex is chosen. The default value is 0, so no jitter
 #' is applied. A recommended value when using it is 1E-5.
+#' @param verbose if TRUE, prints intermediate output
 #' @param ... Any other arguments of the function to be optimimzed, or settings
 #' of the optimization routine
 #' @return \item{out}{ A list containing optimal function arguments
@@ -726,6 +727,7 @@ optimizer <- function(
     fun,
     trparsopt,
     jitter = 0,
+    verbose = TRUE,
     ...)
 {
   if(num_cycles == Inf)
@@ -744,16 +746,19 @@ optimizer <- function(
   out <- NULL
   while(cy <= max_cycles)
   {
-    if(max_cycles > 1) cat(paste('Cycle ',cy,'\n',sep =''))
+    if(max_cycles > 1) {
+      if (verbose) cat(paste('Cycle ',cy,'\n',sep =''))
+    }
     if(optimmethod == 'simplex')
     {
       outnew <- suppressWarnings(simplex(fun = fun,
                                          trparsopt = trparsopt,
                                          optimpars = optimpars,
+                                         verbose = verbose,
                                          ...))
     } else if(optimmethod == 'subplex')
     {
-      minfun1 <- function(fun,trparsopt,...)
+      minfun1 <- function(fun, trparsopt,...)
       {           
         return(-fun(trparsopt = trparsopt,...))
       }
@@ -803,7 +808,7 @@ optimizer <- function(
     }
     if(cy > 1 & (any(is.na(outnew$par)) | any(is.nan(outnew$par)) | is.na(outnew$fvalues) | is.nan(outnew$fvalues) | outnew$conv != 0))
     {
-      cat('The last cycle failed; second last cycle result is returned.\n')
+      if (verbose) cat('The last cycle failed; second last cycle result is returned.\n')
       return(out) 
     } else
     {
@@ -815,11 +820,11 @@ optimizer <- function(
     {
       if(abs(fvalue[cy] - fvalue[cy - 1]) < optimpars[3])
       {
-        if(cy < max_cycles) cat('No more cycles needed.\n')
+        if(cy < max_cycles) if (verbose) cat('No more cycles needed.\n')
         cy <- max_cycles
       } else if(cy == max_cycles)
       {
-        cat('More cycles in optimization recommended.\n')
+        if (verbose) cat('More cycles in optimization recommended.\n')
       }
     }
     cy <- cy + 1

--- a/man/bd_ML.Rd
+++ b/man/bd_ML.Rd
@@ -20,7 +20,7 @@ bd_ML(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   num_cycles = 1,
   methode = "odeint::runge_kutta_cash_karp54",
   verbose = FALSE
@@ -85,7 +85,7 @@ abstolx = absolute tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{num_cycles}{the number of cycles of opimization. If set at Inf, it will

--- a/man/dd_KI_ML.Rd
+++ b/man/dd_KI_ML.Rd
@@ -24,7 +24,7 @@ dd_KI_ML(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   num_cycles = 1,
   methode = "analytical",
   correction = TRUE,
@@ -110,7 +110,7 @@ abstolx = absolute tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{num_cycles}{the number of cycles of opimization. If set at Inf, it will

--- a/man/dd_LR.Rd
+++ b/man/dd_LR.Rd
@@ -22,7 +22,7 @@ dd_LR(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 2000,
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   methode = "analytical"
 )
 }
@@ -96,7 +96,7 @@ tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{methode}{The method used to solve the master equation, default is

--- a/man/dd_ML.Rd
+++ b/man/dd_ML.Rd
@@ -20,7 +20,7 @@ dd_ML(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   num_cycles = 1,
   methode = "analytical",
   verbose = FALSE
@@ -106,7 +106,7 @@ tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{num_cycles}{the number of cycles of opimization. If set at Inf, it will

--- a/man/dd_MS_ML.Rd
+++ b/man/dd_MS_ML.Rd
@@ -24,7 +24,7 @@ dd_MS_ML(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   num_cycles = 1,
   methode = "ode45",
   correction = FALSE,
@@ -108,7 +108,7 @@ tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{num_cycles}{the number of cycles of opimization. If set at Inf, it will

--- a/man/dd_SR_ML.Rd
+++ b/man/dd_SR_ML.Rd
@@ -23,7 +23,7 @@ dd_SR_ML(
   tol = c(0.001, 1e-04, 1e-06),
   maxiter = 1000 * round((1.25)^length(idparsopt)),
   changeloglikifnoconv = FALSE,
-  optimmethod = "subplex",
+  optimmethod = "simplex",
   num_cycles = 1,
   methode = "analytical",
   verbose = FALSE
@@ -105,7 +105,7 @@ tolerance of parameter values in optimization}
 does not converge}
 
 \item{optimmethod}{Method used in optimization of the likelihood. Current
-default is 'subplex'. Alternative is 'simplex' (default of previous
+default is 'simplex'. Alternative is 'subplex' (default of previous
 versions)}
 
 \item{num_cycles}{the number of cycles of opimization. If set at Inf, it will

--- a/man/optimizer.Rd
+++ b/man/optimizer.Rd
@@ -11,6 +11,7 @@ optimizer(
   fun,
   trparsopt,
   jitter = 0,
+  verbose = TRUE,
   ...
 )
 }
@@ -33,6 +34,8 @@ equal to the starting values, with a maximum of 10 cycles.}
 \item{jitter}{Perturbation of an initial parameter value when precisely equal to 0.5;
 this is only relevant when subplex is chosen. The default value is 0, so no jitter
 is applied. A recommended value when using it is 1E-5.}
+
+\item{verbose}{if TRUE, prints intermediate output}
 
 \item{...}{Any other arguments of the function to be optimimzed, or settings
 of the optimization routine}

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -4,7 +4,7 @@
 \alias{simplex}
 \title{Carries out optimization using a simplex algorithm (finding a minimum)}
 \usage{
-simplex(fun, trparsopt, optimpars, ...)
+simplex(fun, trparsopt, optimpars, verbose = TRUE, ...)
 }
 \arguments{
 \item{fun}{Function to be optimized}

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -15,7 +15,9 @@ simplex(fun, trparsopt, optimpars, verbose = TRUE, ...)
 function arguments, relative tolerance in function value, absolute tolerance
 in function arguments, and maximum number of iterations}
 
-\item{...}{Any other arguments of the function to be optimimzed, or settings
+\item{verbose}{adds verbose output of intermediate evaluations}
+
+\item{...}{Any other arguments of the function to be optimimized, or settings
 of the optimization routine}
 }
 \value{


### PR DESCRIPTION
Currently, the simplex optimization function prints out every likelihood evaluation, which is nice for debugging, but for large runs can cause huge log files. 
I have added a 'verbose' flag to mitigate this.